### PR TITLE
Making sure users won't think that the link to www actually should link ...

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		
 		<h4>allizom is home to many development and staging sites for Mozilla projects.</h4>
 
-		<h4>If you were looking for mozilla.org, then you want to go to <a href="https://www.allizom.org">www.allizom.org</a></h4>
+		<h4>If you were looking for mozilla.org staging site, then you want to go to <a href="https://www.allizom.org">www.allizom.org</a></h4>
 	</p>
 	</div>
 	<script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>


### PR DESCRIPTION
...to mozilla.org

I've changed the text "If you were looking for mozilla.org," to "If you were looking for mozilla.org staging site" to make sure users won't get the wrong impression that the link actually links to http://mozilla.org.
